### PR TITLE
feat: Upgrade EKS cluster to 1.30

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -18,7 +18,7 @@ module "eks" {
   version = "20.8.4"
 
   cluster_name    = var.cluster_name
-  cluster_version = "1.29"
+  cluster_version = "1.30"
   subnet_ids      = module.vpc.private_subnets
   vpc_id          = module.vpc.vpc_id
 


### PR DESCRIPTION
This PR upgrades the EKS cluster from version 1.29 to 1.30 as the first step in an incremental upgrade to 1.32.